### PR TITLE
Add Xorg levels (WW,II,EE only) and FATAL

### DIFF
--- a/syntaxes/log.tmLanguage
+++ b/syntaxes/log.tmLanguage
@@ -39,7 +39,7 @@
 			<!-- INFO -->
 			<dict>
 				<key>match</key>
-				<string>\b(HINT|INFO|INFORMATION|Info|NOTICE)\b|(?i)\b(info|information)\:</string>
+				<string>\b(HINT|INFO|INFORMATION|Info|NOTICE|II)\b|(?i)\b(info|information)\:</string>
 
 				<key>name</key>
 				<string>markup.inserted log.info</string>
@@ -57,7 +57,7 @@
 			<!-- WARN -->
 			<dict>
 				<key>match</key>
-				<string>\b(WARNING|WARN|Warn)\b|(?i)\b(warning)\:</string>
+				<string>\b(WARNING|WARN|Warn|WW)\b|(?i)\b(warning)\:</string>
 
 				<key>name</key>
 				<string>markup.deleted log.warning</string>
@@ -75,7 +75,7 @@
 			<!-- ERROR -->
 			<dict>
 				<key>match</key>
-				<string>\b(ALERT|CRITICAL|EMERGENCY|ERROR|FAILURE|FAIL|Fatal|Error)\b|(?i)\b(error)\:</string>
+				<string>\b(ALERT|CRITICAL|EMERGENCY|ERROR|FAILURE|FAIL|Fatal|FATAL|Error|EE)\b|(?i)\b(error)\:</string>
 
 				<key>name</key>
 				<string>string.regexp, strong log.error</string>


### PR DESCRIPTION
The extension doesn't work for me at the moment so afraid I can't test right now. I think I lost my original code as it was perhaps on my ramdisk, so I remember spending longer on this however this should be all that's necessary for it to work so possibly at the time I was stuck down some other rabbithole.

I have added FATAL as mentioned in [this bug](https://github.com/emilast/vscode-logfile-highlighter/issues/84) - not sure if that's what you wanted, the original had `Fatal` but not `FATAL`. I have added basic support for Xorg error levels as in [my bug](https://github.com/emilast/vscode-logfile-highlighter/issues/80); in this case, I have left it only to info, error, and warn - Xorg has a number of other error specifiers that would need more thought as they don't pin down to any of the current categories. also there is `!!` for information, but as I can't test it right now, don't want to add anything that may break the regexp (will try updating VS code in a second in case that helps)